### PR TITLE
feat: add hidden reset-animation trigger for developers

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -31,6 +31,19 @@ function Hero() {
   const isBrowser = useIsBrowser();
   const [shouldAnimate, setShouldAnimate] = useState(false);
 
+  // DX Helper: Ctrl + Alt + R to reset animations for testing
+  useEffect(() => {
+    if (!isBrowser) return;
+    const handleReset = (e) => {
+      if (e.ctrlKey && e.altKey && e.key === 'r') {
+        sessionStorage.clear();
+        window.location.reload();
+      }
+    };
+    window.addEventListener('keydown', handleReset);
+    return () => window.removeEventListener('keydown', handleReset);
+  }, [isBrowser]);
+
   useEffect(() => {
     if (isBrowser) {
       const hasAnimated = sessionStorage.getItem('hasAnimatedHero');


### PR DESCRIPTION
Closes #21. Adds a global keyboard listener Ctrl + Alt + R to clear sessionStorage and reload for easier UI testing.